### PR TITLE
Build with CUDA 12.8.0

### DIFF
--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -9,7 +9,7 @@ channels:
 - nvidia
 dependencies:
 - breathe>=4.35
-- cuda-version=12.5
+- cuda-version=12.8
 - cugraph-dgl==25.2.*,>=0.0.0a0
 - cugraph-pyg==25.2.*,>=0.0.0a0
 - cugraph==25.2.*,>=0.0.0a0
@@ -30,4 +30,4 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx>=8
 - sphinxcontrib-websupport
-name: all_cuda-125_arch-x86_64
+name: all_cuda-128_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ files:
     output: [conda]
     matrix:
       # docs are only built on the latest CUDA version RAPIDS supports
-      cuda: ["12.5"]
+      cuda: ["12.8"]
       arch: [x86_64]
     includes:
       - checks
@@ -51,6 +51,10 @@ dependencies:
               cuda: "12.5"
             packages:
               - cuda-version=12.5
+          - matrix:
+              cuda: "12.8"
+            packages:
+              - cuda-version=12.8
 
   docs:
     common:

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -8,7 +8,7 @@ This guide describes how to install ``nx-cugraph`` and use it in your workflows.
 `nx-cugraph` requires the following:
 
  - **Volta architecture or later NVIDIA GPU, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+**
- - **[CUDA](https://docs.nvidia.com/cuda/index.html) 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, or 12.5**
+ - **[CUDA](https://docs.nvidia.com/cuda/index.html) 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.8**
  - **Python >= 3.10**
  - **[NetworkX](https://networkx.org/documentation/stable/install.html#) >= 3.2 (version 3.4 or higher recommended)**
 

--- a/docs/cugraph-docs/source/tutorials/basic_cugraph.md
+++ b/docs/cugraph-docs/source/tutorials/basic_cugraph.md
@@ -4,7 +4,7 @@
 
 CuGraph is part of [Rapids](https://docs.rapids.ai/user-guide) and has the following system requirements:
  * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
- * CUDA 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, or 12.5
+ * CUDA 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.8
  * Python version 3.10, 3.11, or 3.12
  * NetworkX >= version 3.3 or newer in order to use use [NetworkX Configs](https://networkx.org/documentation/stable/reference/backends.html#module-networkx.utils.configs) **This is required for use of nx-cuGraph, [see below](#cugraph-using-networkx-code).**
 


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/139

Fixes build failures like this:

> ValueError: No matching matrix found in 'cuda_version' for: {'cuda': '12.8', 'arch': 'x86_64', 'py': '3.12'}
Error: Process completed with exit code 1.

([build link](https://github.com/rapidsai/cugraph-docs/actions/runs/13139492622/job/36678167483?pr=96))
