### PR TITLE
require sphinx<8.2.0, update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,9 @@ docs/              @rapidsai/cugraph-doc-codeowners
 # CI code owners
 /.github/                @rapidsai/ci-codeowners
 /ci/                     @rapidsai/ci-codeowners
-/.pre-commit-config.yaml @rapidsai/ci-codeowners
+
+# packaging code owners
+/.pre-commit-config.yaml @rapidsai/packaging-codeowners
+/conda/                  @rapidsai/packaging-codeowners
+dependencies.yaml        @rapidsai/packaging-codeowners
+/build.sh                @rapidsai/packaging-codeowners

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,11 @@
 
 repos:
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.4.0
+    rev: v0.6.0
     hooks:
       - id: verify-alpha-spec
       - id: verify-copyright
+        
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.17.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,6 @@ repos:
     hooks:
       - id: verify-alpha-spec
       - id: verify-copyright
-        
   - repo: https://github.com/rapidsai/dependency-file-generator
     rev: v1.17.0
     hooks:

--- a/conda/environments/all_cuda-128_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-128_arch-x86_64.yaml
@@ -28,6 +28,6 @@ dependencies:
 - recommonmark
 - sphinx-copybutton
 - sphinx-markdown-tables
-- sphinx>=8
+- sphinx>=8,<8.2.0
 - sphinxcontrib-websupport
 name: all_cuda-128_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,8 @@ dependencies:
           - recommonmark
           - sphinx-copybutton
           - sphinx-markdown-tables
-          - sphinx>=8
+          # the ceiling on sphinx can be removed when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
+          - sphinx>=8,<8.2.0
           - sphinxcontrib-websupport
 
   # this repo only uses conda and 1 major version of CUDA, so


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/155

Fixes docs builds by temporarily putting a ceiling on `sphinx`.