### PR TITLE
Build and test with CUDA 12.9.0

### DIFF
--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -9,7 +9,7 @@ channels:
 - nvidia
 dependencies:
 - breathe>=4.35
-- cuda-version=12.8
+- cuda-version=12.9
 - cugraph-dgl==25.6.*,>=0.0.0a0
 - cugraph-pyg==25.6.*,>=0.0.0a0
 - cugraph==25.6.*,>=0.0.0a0
@@ -30,4 +30,4 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx>=8,<8.2.0
 - sphinxcontrib-websupport
-name: all_cuda-128_arch-x86_64
+name: all_cuda-129_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ files:
     output: [conda]
     matrix:
       # docs are only built on the latest CUDA version RAPIDS supports
-      cuda: ["12.8"]
+      cuda: ["12.9"]
       arch: [x86_64]
     includes:
       - checks
@@ -55,6 +55,10 @@ dependencies:
               cuda: "12.8"
             packages:
               - cuda-version=12.8
+          - matrix:
+              cuda: "12.9"
+            packages:
+              - cuda-version=12.9
 
   docs:
     common:

--- a/docs/cugraph-docs/source/graph_support/DGL_support.md
+++ b/docs/cugraph-docs/source/graph_support/DGL_support.md
@@ -17,7 +17,7 @@ mamba install cugraph-dgl -c rapidsai-nightly -c rapidsai -c pytorch -c conda-fo
 
 ### Create the conda development environment
 ```
-conda env create -n cugraph_dgl_dev --file conda/environments/all_cuda-125_arch-x86_64.yaml
+conda env create -n cugraph_dgl_dev --file conda/environments/all_cuda-129_arch-x86_64.yaml
 ```
 
 ### Install  in editable mode

--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -40,7 +40,7 @@ Replace the package name in the example below to the one you want to install.
 Install and update cuGraph using the conda command:
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.0
+conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.9
 ```
 
 Alternatively, use `cuda-version=11.8` for packages supporting CUDA 11.

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -42,7 +42,7 @@ files](https://github.com/rapidsai/cugraph/blob/main/conda/environments).
 conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-118_arch-x86_64.yaml
 
 # for CUDA 12.x
-conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-125_arch-x86_64.yaml
+conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
 
 
 # activate the environment
@@ -60,7 +60,7 @@ conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_
 conda activate cugraph_dev
 
 # for CUDA 12.x
-conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-125_arch-x86_64.yaml
+conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
 conda activate cugraph_dev
 
 


### PR DESCRIPTION
This PR uses CUDA 12.9.0 to build and test.

xref: https://github.com/rapidsai/build-planning/issues/173