### PR TITLE
Use CUDA 12.9 in Conda, Devcontainers, Spark, GHA, etc.

### DIFF
--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -40,7 +40,7 @@ Replace the package name in the example below to the one you want to install.
 Install and update cuGraph using the conda command:
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.8
+conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.9
 ```
 
 Alternatively, use `cuda-version=11.8` for packages supporting CUDA 11.

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -8,7 +8,7 @@ This guide describes how to install ``nx-cugraph`` and use it in your workflows.
 `nx-cugraph` requires the following:
 
  - **Volta architecture or later NVIDIA GPU, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+**
- - **[CUDA](https://docs.nvidia.com/cuda/index.html) 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.8**
+ - **[CUDA](https://docs.nvidia.com/cuda/index.html) 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.9**
  - **Python >= 3.10**
  - **[NetworkX](https://networkx.org/documentation/stable/install.html#) >= 3.2 (version 3.4 or higher recommended)**
 

--- a/docs/cugraph-docs/source/tutorials/basic_cugraph.md
+++ b/docs/cugraph-docs/source/tutorials/basic_cugraph.md
@@ -4,7 +4,7 @@
 
 CuGraph is part of [Rapids](https://docs.rapids.ai/user-guide) and has the following system requirements:
  * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
- * CUDA 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.8
+ * CUDA 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.9
  * Python version 3.10, 3.11, 3.12, or 3.13
  * NetworkX >= version 3.3 or newer in order to use use [NetworkX Configs](https://networkx.org/documentation/stable/reference/backends.html#module-networkx.utils.configs) **This is required for use of nx-cuGraph, [see below](#cugraph-using-networkx-code).**
 


### PR DESCRIPTION
Addressing issues:
* https://github.com/rapidsai/build-planning/issues/195
* https://github.com/rapidsai/build-planning/issues/173

## Description

Use CUDA 12.9 throughout different build and test environments.