### PR TITLE
Removing CUDA 11 references and fixing outdated wholegraph info

### DIFF
--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -43,8 +43,6 @@ Install and update cuGraph using the conda command:
 conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.9
 ```
 
-Alternatively, use `cuda-version=11.8` for packages supporting CUDA 11.
-
 Note: This conda installation only applies to Linux and Python versions 3.10/3.11/3.12/3.13.
 
 <br>
@@ -55,8 +53,6 @@ cuGraph, and all of RAPIDS, is available via pip.
 ```
 pip install cugraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
-
-Replace `-cu12` with `-cu11` for packages supporting CUDA 11.
 
 Also available:
  * cugraph-dgl-cu12

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -12,7 +12,7 @@ __Compilers:__
 * `nvcc`          version 11.5+
 
 __CUDA:__
-* CUDA 11.8+
+* CUDA 12.0+
 * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
 
 Further details and download links for these prerequisites are available on the
@@ -38,11 +38,9 @@ environment YAML
 files](https://github.com/rapidsai/cugraph/blob/main/conda/environments).
 
 ```bash
-# for CUDA 11.x
-conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-118_arch-x86_64.yaml
 
 # for CUDA 12.x
-conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-128_arch-x86_64.yaml
+conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
 
 
 # activate the environment
@@ -55,12 +53,9 @@ conda deactivate
 The environment can be updated as cugraph adds/removes/updates its dependencies. To do so, run:
 
 ```bash
-# for CUDA 11.x
-conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-118_arch-x86_64.yaml
-conda activate cugraph_dev
 
 # for CUDA 12.x
-conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-128_arch-x86_64.yaml
+conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
 conda activate cugraph_dev
 
 
@@ -201,8 +196,8 @@ Next the env_vars.sh file needs to be edited
 vi ./etc/conda/activate.d/env_vars.sh
 
 #!/bin/bash
-export PATH=/usr/local/cuda-11.0/bin:$PATH # or cuda-11.1 if using CUDA 11.1 and cuda-11.2 if using CUDA 11.2, respectively
-export LD_LIBRARY_PATH=/usr/local/cuda-11.0/lib64:$LD_LIBRARY_PATH # or cuda-11.1 if using CUDA 11.1 and cuda-11.2 if using CUDA 11.2, respectively
+export PATH=/usr/local/cuda-12.0/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH
 ```
 
 ```

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -196,8 +196,6 @@ Next the env_vars.sh file needs to be edited
 vi ./etc/conda/activate.d/env_vars.sh
 
 #!/bin/bash
-export PATH=/usr/local/cuda-12.0/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/cuda-12.0/lib64:$LD_LIBRARY_PATH
 ```
 
 ```

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -34,17 +34,17 @@ conda install -c rapidsai -c conda-forge -c nvidia nx-cugraph
 ### pip
 **Nightly version**
 ```bash
-pip install nx-cugraph-cu11 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+pip install nx-cugraph-cu12 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
 ```
 
 **Stable version**
 ```bash
-pip install nx-cugraph-cu11 --extra-index-url https://pypi.nvidia.com
+pip install nx-cugraph-cu12 --extra-index-url https://pypi.nvidia.com
 ```
 
 <div style="border: 1px solid #ccc; background-color: #f9f9f9; padding: 10px; border-radius: 5px;">
 
 **Note:**
- - The `pip install` examples above are for CUDA 11. To install for CUDA 12, replace `-cu11` with `-cu12`
+ - The `pip install` examples above are for CUDA 12. CUDA 11 support has been discontinued.
 
 </div>

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -44,7 +44,4 @@ pip install nx-cugraph-cu12 --extra-index-url https://pypi.nvidia.com
 
 <div style="border: 1px solid #ccc; background-color: #f9f9f9; padding: 10px; border-radius: 5px;">
 
-**Note:**
- - The `pip install` examples above are for CUDA 12. CUDA 11 support has been discontinued.
-
 </div>

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -8,7 +8,7 @@ This guide describes how to install ``nx-cugraph`` and use it in your workflows.
 `nx-cugraph` requires the following:
 
  - **Volta architecture or later NVIDIA GPU, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+**
- - **[CUDA](https://docs.nvidia.com/cuda/index.html) 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.9**
+ - **[CUDA](https://docs.nvidia.com/cuda/index.html) 12.0, 12.2, 12.5, or 12.9**
  - **Python >= 3.10**
  - **[NetworkX](https://networkx.org/documentation/stable/install.html#) >= 3.2 (version 3.4 or higher recommended)**
 

--- a/docs/cugraph-docs/source/tutorials/basic_cugraph.md
+++ b/docs/cugraph-docs/source/tutorials/basic_cugraph.md
@@ -4,7 +4,7 @@
 
 CuGraph is part of [Rapids](https://docs.rapids.ai/user-guide) and has the following system requirements:
  * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
- * CUDA 11.2, 11.4, 11.5, 11.8, 12.0, 12.2, 12.5, or 12.9
+ * CUDA 12.0, 12.2, 12.5, or 12.9
  * Python version 3.10, 3.11, 3.12, or 3.13
  * NetworkX >= version 3.3 or newer in order to use use [NetworkX Configs](https://networkx.org/documentation/stable/reference/backends.html#module-networkx.utils.configs) **This is required for use of nx-cuGraph, [see below](#cugraph-using-networkx-code).**
 

--- a/docs/cugraph-docs/source/tutorials/cugraph_notebooks.md
+++ b/docs/cugraph-docs/source/tutorials/cugraph_notebooks.md
@@ -58,7 +58,7 @@ Running the example in these notebooks requires:
 * cuGraph is dependent on the latest version of cuDF.  Please install all components of RAPIDS
 * Python 3.10+
 * A system with an NVIDIA GPU: Volta architecture or newer
-* CUDA 11.4+
+* CUDA 12.0+
 
 ## Copyright
 

--- a/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
@@ -34,7 +34,7 @@ Replace the package name in the example below to the one you want to install.
 Install and update WholeGraph using the conda command:
 
 ```bash
-conda install -c rapidsai -c conda-forge -c nvidia wholegraph cudatoolkit=11.8
+conda install -c rapidsai -c conda-forge -c nvidia wholegraph cudatoolkit=12.9
 ```
 
 <br>

--- a/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
@@ -43,7 +43,7 @@ conda install -c rapidsai -c conda-forge -c nvidia wholegraph cudatoolkit=12.9
 wholegraph, and all of RAPIDS, is available via pip.
 
 ```
-pip install wholegraph-cu11 --extra-index-url=https://pypi.nvidia.com
+pip install wholegraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
 
 <br>

--- a/docs/cugraph-docs/source/wholegraph/installation/source_build.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/source_build.md
@@ -15,7 +15,7 @@ __Compiler__:
 * `cmake`       version 3.26.4+
 
 __CUDA__:
-* CUDA 11.8+
+* 12.0+
 * Volta architecture or better
 
 You can obtain CUDA from [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads).
@@ -29,8 +29,8 @@ __Other Packages__:
 * scikit-build-core
 * nanobind>=0.2.0
 
-## Building wholegraph
-To install wholegraph from source, ensure the dependencies are met.
+## Building gnn
+To install gnn from source, ensure the dependencies are met.
 
 ### Clone Repo and Configure Conda Environment
 __GIT clone a version of the repository__
@@ -40,9 +40,9 @@ __GIT clone a version of the repository__
   export WHOLEGRAPH_HOME=$(pwd)/wholegraph
 
   # Download the wholegraph repo - if you have a forked version, use that path here instead
-  git clone https://github.com/rapidsai/wholegraph.git $WHOLEGRAPH_HOME
+  git clone https://github.com/rapidsai/cugraph-gnn.git $CUGRAPH_GNN_HOME
 
-  cd $WHOLEGRAPH_HOME
+  cd $CUGRAPH_GNN_HOME
   ```
 
 __Create the conda development environment__
@@ -50,11 +50,11 @@ __Create the conda development environment__
 ```bash
 # create the conda environment (assuming in base `wholegraph` directory)
 
-# for CUDA 11.x
-conda env create --name wholegraph_dev --file conda/environments/all_cuda-118_arch-x86_64.yaml
+# for CUDA 12.x
+conda env create --name cugraph_gnn_dev --file conda/environments/all_cuda-118_arch-x86_64.yaml
 
 # activate the environment
-conda activate wholegraph_dev
+conda activate cugraph_gnn_dev
 
 # to deactivate an environment
 conda deactivate
@@ -68,7 +68,7 @@ conda deactivate
 # Where XXX is the CUDA version
 conda env update --name wholegraph_dev --file conda/environments/all_cuda-XXX_arch-x86_64.yaml
 
-conda activate wholegraph_dev
+conda activate cugraph_gnn_dev
 ```
 
 
@@ -77,7 +77,7 @@ Using the `build.sh` script make compiling and installing wholegraph a
 breeze. To build and install, simply do:
 
 ```bash
-$ cd $WHOLEGRAPH_HOME
+$ cd $CUGRAPH_GNN_HOME
 $ ./build.sh clean
 $ ./build.sh libwholegraph
 $ ./build.sh pylibwholegraph
@@ -88,23 +88,24 @@ There are several other options available on the build script for advanced users
 ```bash
 build.sh [<target> ...] [<flag> ...]
  where <target> is:
-   clean                    - remove all existing build artifacts and configuration (start over).
-   uninstall                - uninstall libwholegraph and pylibwholegraph from a prior build/install (see also -n)
-   libwholegraph            - build the libwholegraph C++ library.
-   pylibwholegraph          - build the pylibwholegraph Python package.
-   tests                    - build the C++ (OPG) tests.
-   benchmarks               - build benchmarks.
-   docs                     - build the docs
+   clean                      - remove all existing build artifacts and configuration (start over)
+   uninstall                  - uninstall libwholegraph and GNN Python packages from a prior build/install (see also -n)
+   cugraph-pyg                - build the cugraph-pyg Python package
+   pylibwholegraph            - build the pylibwholegraph Python package
+   libwholegraph              - build the libwholegraph library
+   tests                      - build the C++ tests
+   benchmarks                 - build benchmarks
+   all                        - build everything
  and <flag> is:
-   -v                          - verbose build mode
-   -g                          - build for debug
-   -n                          - no install step
+   -v                         - verbose build mode
+   -g                         - build for debug
+   -n                         - do not install after a successful build (does not affect Python packages)
+   --pydevelop                - install the Python packages in editable mode
    --allgpuarch               - build for all supported GPU architectures
-   --cmake-args=\\\"<args>\\\" - add arbitrary CMake arguments to any cmake call
+   --enable-nvshmem            - build with nvshmem support (beta).
    --compile-cmd               - only output compile commands (invoke CMake without build)
    --clean                    - clean an individual target (note: to do a complete rebuild, use the clean target described above)
-   -h | --h[elp]               - print this text
-
+   -h                         - print this text
  default action (no args) is to build and install 'libwholegraph' then 'pylibwholegraph' targets
 
 examples:
@@ -125,10 +126,10 @@ CMake depends on the `nvcc` executable being on your path or defined in `$CUDACX
 This project uses cmake for building the C/C++ library. To configure cmake, run:
 
   ```bash
-  # Set the location to wholegraph in an environment variable WHOLEGRAPH_HOME
-  export WHOLEGRAPH_HOME=$(pwd)/wholegraph
+  # Set the location to wholegraph in an environment variable CUGRAPH_GNN_HOME
+  export CUGRAPH_GNN_HOME=$(pwd)/cugraph_gnn
 
-  cd $WHOLEGRAPH_HOME
+  cd $CUGRAPH_GNN_HOME
   cd cpp                                        # enter cpp directory
   mkdir build                                   # create build directory
   cd build                                      # enter the build directory
@@ -145,7 +146,7 @@ The default installation locations are `$CMAKE_INSTALL_PREFIX/lib` and `$CMAKE_I
 Build and Install the Python packages to your Python path:
 
 ```bash
-cd $WHOLEGRAPH_HOME
+cd $CUGRAPH_GNN_HOME
 cd python
 cd pylibwholegraph
 python setup.py build_ext --inplace
@@ -159,7 +160,7 @@ Run either the C++ or the Python tests with datasets
   - **Python tests with datasets**
 
     ```bash
-    cd $WHOLEGRAPH_HOME
+    cd $CUGRAPH_GNN_HOME
     cd python
     pytest
     ```
@@ -170,7 +171,7 @@ Run either the C++ or the Python tests with datasets
 
     ```bash
     # Run the tests
-    cd $WHOLEGRAPH_HOME
+    cd $CUGRAPH_GNN_HOME
     cd cpp/build
     gtests/PARALLEL_UTILS_TESTS		# this is an executable file
     ```
@@ -178,9 +179,6 @@ Run either the C++ or the Python tests with datasets
 
 Note: This conda installation only applies to Linux and Python versions 3.10, 3.11, 3.12, and 3.13.
 
-## Creating documentation
-
-Python API documentation can be generated from _./docs/wholegraph directory_. Or through using "./build.sh docs"
 
 ## Attribution
 Portions adopted from https://github.com/pytorch/pytorch/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Removing the CUDA 11 options. The migration to cugraph-gnn was not changed in the wholegraph docs. This is a first attempt at changing that.

Resolves #140 