### PR TITLE
WIP: remove cugraph-dgl references

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -44,7 +44,6 @@ NEXT_SHORT_TAG_PEP440=$(python -c "from packaging.version import Version; print(
 
 DEPENDENCIES=(
   cugraph
-  cugraph-dgl
   cugraph-pyg
   libcugraph
   libcugraph_etl

--- a/conda/environments/all_cuda-129_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-129_arch-x86_64.yaml
@@ -8,10 +8,8 @@ channels:
 dependencies:
 - breathe>=4.35
 - cuda-version=12.9
-- cugraph-dgl==25.8.*,>=0.0.0a0
 - cugraph-pyg==25.8.*,>=0.0.0a0
 - cugraph==25.8.*,>=0.0.0a0
-- dglteam/label/th24_cu124::dgl
 - doxygen
 - graphviz
 - ipython

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -82,9 +82,7 @@ dependencies:
       - output_types: [conda]
         packages:
           - cugraph==25.8.*,>=0.0.0a0
-          - cugraph-dgl==25.8.*,>=0.0.0a0
           - cugraph-pyg==25.8.*,>=0.0.0a0
-          - 'dglteam/label/th24_cu124::dgl'
           - libcugraph==25.8.*,>=0.0.0a0
           - libcugraph_etl==25.8.*,>=0.0.0a0
           - pylibcugraph==25.8.*,>=0.0.0a0

--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -30,7 +30,6 @@ cuGraph Conda packages
    * libcugraph
  * cugraph-service-client
  * cugraph-service-server
- * cugraph-dgl
  * cugraph-pyg
  * nx-cugraph
 
@@ -55,7 +54,6 @@ pip install cugraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
 
 Also available:
- * cugraph-dgl-cu12
  * cugraph-pyg-cu12
  * nx-cugraph-cu12
 

--- a/docs/cugraph-docs/source/sphinxext/github_link.py
+++ b/docs/cugraph-docs/source/sphinxext/github_link.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023, NVIDIA CORPORATION.
+# Copyright (c) 2019-2025, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -94,7 +94,6 @@ def _linkcode_resolve(domain, info, url_fmt, revision):
     module_name = obj_module.__name__.split('.')[0]
 
     module_dir_dict = {
-        "cugraph_dgl": "cugraph-dgl",
         "cugraph_pyg": "cugraph-pyg",
         "cugraph_service_client": "cugraph-service/client",
         "cugraph_service_server": "cugraph-service/server",

--- a/docs/cugraph-docs/source/wholegraph/basics/wholegraph_intro.md
+++ b/docs/cugraph-docs/source/wholegraph/basics/wholegraph_intro.md
@@ -3,7 +3,7 @@ WholeGraph helps train large-scale Graph Neural Networks(GNN).
 WholeGraph provides underlying storage structure called WholeMemory.
 WholeMemory is a Tensor like storage and provides multi-GPU support.
 It is optimized for NVLink systems like DGX A100 servers.
-By working together with cuGraph, cuGraph-DGL, cuGraph-PyG, and upstream DGL and PyG,
+By working together with cuGraph, cuGraph-PyG, and PyG,
 it will be easy to build GNN applications.
 
 ## WholeMemory

--- a/docs/cugraph-docs/source/wholegraph/installation/container.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/container.md
@@ -21,10 +21,5 @@ RUN pip3 install -U py
 RUN pip3 install Cython setuputils3 scikit-build nanobind pytest-forked pytest
 ```
 
-To run GNN applications, you may also need DGL and/or PyG libraries to run the GNN layers.
-You may refer to [DGL](https://www.dgl.ai/pages/start.html) or [PyG](https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html)
-For example, to install DGL, you may need to add:
-
-```dockerfile
-RUN pip3 install  dgl -f https://data.dgl.ai/wheels/torch-2.3/cu118/repo.html
-```
+To run GNN applications, you may also need PyG libraries to run the GNN layers.
+You may refer to [PyG](https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html)


### PR DESCRIPTION
`cugraph-dgl` was removed in 25.08, here: https://github.com/rapidsai/cugraph-gnn/pull/210

See also: https://docs.rapids.ai/notices/rsn0046/

But this repository still references it. That'll break the 25.08 release of this repository, and it's breaking the nightly builds of the 25.10 release:

```text
error    libmamba Could not solve for environment specs
    The following package could not be installed
    └─ cugraph-dgl =25.10,>=0.0.0a0 * does not exist (perhaps a typo or a missing channel).
critical libmamba Could not solve for environment specs
```

([build link](https://github.com/rapidsai/cugraph-docs/actions/runs/16594793920/job/46938721265#step:11:56))

This removes lingering `cugraph-dgl` and DGL stuff from this project.

## Notes for Reviewers

Found these like this:

```shell
git grep -i dgl
```