### PR TITLE
build and test with CUDA 13.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
   docs-build:
     if: github.ref_type == 'branch'
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda13.0
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
   docs-build:
     if: github.ref_type == 'branch'
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda13.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.10
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - checks
       - docs-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda13.0
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -31,14 +31,14 @@ jobs:
   checks:
     secrets: inherit
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda13.0
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
   docs-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.10
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda13.0
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - checks
       - docs-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda13.0
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.10
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -31,14 +31,14 @@ jobs:
   checks:
     secrets: inherit
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda13.0
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-25.10
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
   docs-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda13.0
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@branch-25.10
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,17 @@
 
 repos:
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v0.6.0
+    rev: v0.7.0
     hooks:
       - id: verify-alpha-spec
       - id: verify-copyright
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.19.0
+    rev: v1.20.0
     hooks:
       - id: rapids-dependency-file-generator
-        args: ["--clean"]
+        args: ["--clean", "--warn-all", "--strict"]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]

--- a/conda/environments/all_cuda-130_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-130_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 - conda-forge
 dependencies:
 - breathe>=4.35
-- cuda-version=12.9
+- cuda-version=13.0
 - cugraph-pyg==25.10.*,>=0.0.0a0
 - cugraph==25.10.*,>=0.0.0a0
 - doxygen
@@ -26,4 +26,4 @@ dependencies:
 - sphinx-copybutton
 - sphinx-markdown-tables
 - sphinxcontrib-websupport
-name: all_cuda-129_arch-x86_64
+name: all_cuda-130_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ files:
     output: [conda]
     matrix:
       # docs are only built on the latest CUDA version RAPIDS supports
-      cuda: ["12.9"]
+      cuda: ["13.0"]
       arch: [x86_64]
     includes:
       - checks
@@ -38,25 +38,9 @@ dependencies:
       - output_types: [conda]
         matrices:
           - matrix:
-              cuda: "12.0"
+              cuda: "13.0"
             packages:
-              - cuda-version=12.0
-          - matrix:
-              cuda: "12.2"
-            packages:
-              - cuda-version=12.2
-          - matrix:
-              cuda: "12.5"
-            packages:
-              - cuda-version=12.5
-          - matrix:
-              cuda: "12.8"
-            packages:
-              - cuda-version=12.8
-          - matrix:
-              cuda: "12.9"
-            packages:
-              - cuda-version=12.9
+              - cuda-version=13.0
 
   docs:
     common:

--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -39,6 +39,10 @@ Replace the package name in the example below to the one you want to install.
 Install and update cuGraph using the conda command:
 
 ```bash
+# CUDA 13
+conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=13.0
+
+# CUDA 12
 conda install -c rapidsai -c conda-forge -c nvidia cugraph cuda-version=12.9
 ```
 
@@ -49,12 +53,17 @@ Note: This conda installation only applies to Linux and Python versions 3.10/3.1
 ## PIP
 cuGraph, and all of RAPIDS, is available via pip.
 
-```
+```shell
+# CUDA 13
+pip install cugraph-cu13 --extra-index-url=https://pypi.nvidia.com
+
+# CUDA 12
 pip install cugraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
 
 Also available:
- * cugraph-pyg-cu12
- * nx-cugraph-cu12
+
+* `cugraph-pyg-cu{12,13}`
+* `nx-cugraph-cu{12, 13}`
 
 <br>

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -39,10 +39,8 @@ environment YAML
 files](https://github.com/rapidsai/cugraph/blob/main/conda/environments).
 
 ```bash
-
-# for CUDA 12.x
-conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
-
+# for CUDA 13.x
+conda env create --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-130_arch-x86_64.yaml
 
 # activate the environment
 conda activate cugraph_dev
@@ -54,13 +52,9 @@ conda deactivate
 The environment can be updated as cugraph adds/removes/updates its dependencies. To do so, run:
 
 ```bash
-
-# for CUDA 12.x
-conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-129_arch-x86_64.yaml
+# for CUDA 13.x
+conda env update --name cugraph_dev --file $CUGRAPH_HOME/conda/environments/all_cuda-130_arch-x86_64.yaml
 conda activate cugraph_dev
-
-
-
 ```
 
 ### Build and Install

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -32,13 +32,24 @@ conda install -c rapidsai -c conda-forge -c nvidia nx-cugraph
 ```
 
 ### pip
+
 **Nightly version**
+
 ```bash
+# CUDA 13
+pip install nx-cugraph-cu13 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
+
+# CUDA 12
 pip install nx-cugraph-cu12 --extra-index-url https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
 ```
 
 **Stable version**
+
 ```bash
+# CUDA 13
+pip install nx-cugraph-cu13 --extra-index-url https://pypi.nvidia.com
+
+# CUDA 12
 pip install nx-cugraph-cu12 --extra-index-url https://pypi.nvidia.com
 ```
 

--- a/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
@@ -34,15 +34,24 @@ Replace the package name in the example below to the one you want to install.
 Install and update WholeGraph using the conda command:
 
 ```bash
+# CUDA 13
+conda install -c rapidsai -c conda-forge -c nvidia wholegraph cudatoolkit=13.0
+
+# CUDA 12
 conda install -c rapidsai -c conda-forge -c nvidia wholegraph cudatoolkit=12.9
 ```
 
 <br>
 
-## PIP
-wholegraph, and all of RAPIDS, is available via pip.
+## pip
 
-```
+wholegraph, and all of RAPIDS, is available via `pip`.
+
+```shell
+# CUDA 13
+pip install wholegraph-cu13 --extra-index-url=https://pypi.nvidia.com
+
+# CUDA 12
 pip install wholegraph-cu12 --extra-index-url=https://pypi.nvidia.com
 ```
 

--- a/docs/cugraph-docs/source/wholegraph/installation/source_build.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/source_build.md
@@ -50,8 +50,8 @@ __Create the conda development environment__
 ```bash
 # create the conda environment (assuming in base `wholegraph` directory)
 
-# for CUDA 12.x
-conda env create --name cugraph_gnn_dev --file conda/environments/all_cuda-129_arch-x86_64.yaml
+# for CUDA 13.x
+conda env create --name cugraph_gnn_dev --file conda/environments/all_cuda-130_arch-x86_64.yaml
 
 # activate the environment
 conda activate cugraph_gnn_dev


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/208

* uses CUDA 13.0.0 to build and test
* updates to latest versions of all `pre-commit` hooks (including stricter `rapids-dependency-file-generator` via https://github.com/rapidsai/dependency-file-generator/pull/163)