### PR TITLE
Restore CUDA environment script in documentation

### DIFF
--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -191,6 +191,8 @@ Next the env_vars.sh file needs to be edited
 vi ./etc/conda/activate.d/env_vars.sh
 
 #!/bin/bash
+export PATH=/usr/local/cuda-13.0/bin:$PATH # or cuda-12.9 depending on the version you're using
+export LD_LIBRARY_PATH=/usr/local/cuda-13.0/lib64:$LD_LIBRARY_PATH # or cuda-12.9
 ```
 
 ```


### PR DESCRIPTION
An important part of the script that sets environment variables was mistakenly deleted in #141.

This PR restores the missing lines, updated to reference CUDA 13.