### PR TITLE
Require CUDA 12.2+

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,10 +38,6 @@ dependencies:
       - output_types: [conda]
         matrices:
           - matrix:
-              cuda: "12.0"
-            packages:
-              - cuda-version=12.0
-          - matrix:
               cuda: "12.2"
             packages:
               - cuda-version=12.2

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -9,11 +9,11 @@ compatible, but are not currently tested.
 
 __Compilers:__
 * `gcc` version 13.3+
-* `nvcc` version 12.0+
+* `nvcc` version 12.2+
 * `cmake` version 3.29.6+
 
 __CUDA:__
-* CUDA 12.0+
+* CUDA 12.2+
 * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
 
 Further details and download links for these prerequisites are available on the

--- a/docs/cugraph-docs/source/nx_cugraph/installation.md
+++ b/docs/cugraph-docs/source/nx_cugraph/installation.md
@@ -8,7 +8,7 @@ This guide describes how to install ``nx-cugraph`` and use it in your workflows.
 `nx-cugraph` requires the following:
 
  - **Volta architecture or later NVIDIA GPU, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+**
- - **[CUDA](https://docs.nvidia.com/cuda/index.html) 12.0+**
+ - **[CUDA](https://docs.nvidia.com/cuda/index.html) 12.2+**
  - **Python >= 3.10**
  - **[NetworkX](https://networkx.org/documentation/stable/install.html#) >= 3.2 (version 3.4 or higher recommended)**
 

--- a/docs/cugraph-docs/source/tutorials/basic_cugraph.md
+++ b/docs/cugraph-docs/source/tutorials/basic_cugraph.md
@@ -4,7 +4,7 @@
 
 cuGraph is part of [RAPIDS](https://docs.rapids.ai/user-guide/) and has the following system requirements:
  * NVIDIA GPU, Volta architecture or later, with [compute capability](https://developer.nvidia.com/cuda-gpus) 7.0+
- * CUDA 12.0+
+ * CUDA 12.2+
  * Python version 3.10, 3.11, 3.12, or 3.13
  * NetworkX >= version 3.3 or newer in order to use use [NetworkX Configs](https://networkx.org/documentation/stable/reference/backends.html#module-networkx.utils.configs) **This is required for use of nx-cuGraph, [see below](#cugraph-using-networkx-code).**
 

--- a/docs/cugraph-docs/source/tutorials/cugraph_notebooks.md
+++ b/docs/cugraph-docs/source/tutorials/cugraph_notebooks.md
@@ -58,7 +58,7 @@ Running the example in these notebooks requires:
 * cuGraph is dependent on the latest version of cuDF.  Please install all components of RAPIDS
 * Python 3.10+
 * A system with an NVIDIA GPU: Volta architecture or newer
-* CUDA 12.0+
+* CUDA 12.2+
 
 ## Copyright
 

--- a/docs/cugraph-docs/source/wholegraph/installation/source_build.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/source_build.md
@@ -15,7 +15,7 @@ __Compiler__:
 * `cmake`       version 3.26.4+
 
 __CUDA__:
-* 12.0+
+* 12.2+
 * Volta architecture or better
 
 You can obtain CUDA from [https://developer.nvidia.com/cuda-downloads](https://developer.nvidia.com/cuda-downloads).


### PR DESCRIPTION
Bump minimum CUDA version from 12.0 to 12.2.

<hr>

Part of issue:
* https://github.com/rapidsai/build-planning/issues/223