### PR TITLE
refactored update-version.sh to handle new branching strategy

### DIFF
--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -13,8 +13,66 @@
 # limitations under the License.
 
 ## Usage
-# bash update-version.sh <new_version>
+# Primary interface: ./ci/release/update-version.sh --run-context=main|release <new_version>
+# Fallback: Environment variable support for automation needs
+# NOTE: Must be run from the root of the repository
+#
+# CLI args take precedence when both are provided
+# If neither RUN_CONTEXT nor --run-context is provided, defaults to main
+#
+# Examples:
+#   ./ci/release/update-version.sh --run-context=main 25.12.00
+#   ./ci/release/update-version.sh --run-context=release 25.12.00
+#   RAPIDS_RUN_CONTEXT=main ./ci/release/update-version.sh 25.12.00
 
+# Verify we're running from the repository root
+if [[ ! -f "VERSION" ]] || [[ ! -f "ci/release/update-version.sh" ]] || [[ ! -d "docs" ]]; then
+    echo "Error: This script must be run from the root of the cugraph-docs repository"
+    echo ""
+    echo "Usage:"
+    echo "  cd /path/to/cugraph-docs"
+    echo "  ./ci/release/update-version.sh --run-context=main|release <new_version>"
+    echo ""
+    echo "Example:"
+    echo "  ./ci/release/update-version.sh --run-context=main 25.12.00"
+    exit 1
+fi
+
+# Parse command line arguments
+POSITIONAL_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --run-context=*)
+      CLI_RUN_CONTEXT="${1#*=}"
+      shift
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Restore positional parameters
+set -- "${POSITIONAL_ARGS[@]}"
+
+# Determine RUN_CONTEXT with precedence: CLI > Environment > Default
+if [[ -n "${CLI_RUN_CONTEXT:-}" ]]; then
+    RUN_CONTEXT="${CLI_RUN_CONTEXT}"
+    echo "Using run-context from CLI: ${RUN_CONTEXT}"
+elif [[ -n "${RAPIDS_RUN_CONTEXT:-}" ]]; then
+    RUN_CONTEXT="${RAPIDS_RUN_CONTEXT}"
+    echo "Using RUN_CONTEXT from environment: ${RUN_CONTEXT}"
+else
+    RUN_CONTEXT="main"
+    echo "Using default run-context: ${RUN_CONTEXT}"
+fi
+
+# Validate RUN_CONTEXT
+if [[ "${RUN_CONTEXT}" != "main" && "${RUN_CONTEXT}" != "release" ]]; then
+    echo "Error: Invalid run-context '${RUN_CONTEXT}'. Must be 'main' or 'release'"
+    exit 1
+fi
 
 # Format is YY.MM.PP - no leading 'v' or trailing 'a'
 NEXT_FULL_TAG=$1
@@ -27,7 +85,14 @@ NEXT_MAJOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[1]}')
 NEXT_MINOR=$(echo "$NEXT_FULL_TAG" | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
-echo "Preparing release $CURRENT_TAG => $NEXT_FULL_TAG"
+# Determine branch name based on context
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    RAPIDS_BRANCH_NAME="main"
+    echo "Preparing development branch update ${CURRENT_TAG} => ${NEXT_FULL_TAG} (targeting main branch)"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    RAPIDS_BRANCH_NAME="release/${NEXT_SHORT_TAG}"
+    echo "Preparing release branch update ${CURRENT_TAG} => ${NEXT_FULL_TAG} (targeting release/${NEXT_SHORT_TAG} branch)"
+fi
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
@@ -57,9 +122,9 @@ for DEP in "${DEPENDENCIES[@]}"; do
   done
 done
 
-# CI files
+# CI files - context-aware branch references
 for FILE in .github/workflows/*.yaml; do
-  sed_runner "/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "/shared-workflows/ s|@.*|@${RAPIDS_BRANCH_NAME}|g" "${FILE}"
 done
 
 # Update container_image version in workflow files


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224