### PR TITLE
removed reference to uniform_neighbor_sample

### DIFF
--- a/docs/cugraph-docs/source/api_docs/cugraph/sampling.rst
+++ b/docs/cugraph-docs/source/api_docs/cugraph/sampling.rst
@@ -16,7 +16,6 @@ single-GPU
    cugraph.heterogeneous_neighbor_sample
    cugraph.homogeneous_neighbor_sample
    cugraph.random_walks
-   cugraph.uniform_neighbor_sample
 
 multi-GPU
 ^^^^^^^^^
@@ -25,7 +24,6 @@ multi-GPU
 
    cugraph.dask.sampling.biased_random_walks.biased_random_walks
    cugraph.dask.sampling.random_walks.random_walks
-   cugraph.dask.sampling.uniform_neighbor_sample.uniform_neighbor_sample
    cugraph.dask.sampling.uniform_random_walks.uniform_random_walks
 
 Node2Vec


### PR DESCRIPTION
The cugraph repo had the `uniform_neighbor_sample` calls removed as part of: 

* https://github.com/rapidsai/cugraph/pull/5335

This PR removes those references from the documentation.