### PR TITLE
Build and test with CUDA 13.2.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
   docs-build:
     if: github.ref_type == 'branch'
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.2.0
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
       - checks
       - docs-build
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.2.0
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -31,14 +31,14 @@ jobs:
   checks:
     secrets: inherit
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.2.0
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
   docs-build:
     needs: checks
     secrets: inherit
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.2.0
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 - pyg
 dependencies:
 - breathe>=4.35
-- cuda-version=13.1
+- cuda-version=13.2
 - cugraph-pyg==26.6.*,>=0.0.0a0
 - cugraph==26.6.*,>=0.0.0a0
 - doxygen
@@ -25,4 +25,4 @@ dependencies:
 - sphinx-copybutton
 - sphinx-markdown-tables
 - sphinxcontrib-websupport
-name: all_cuda-131_arch-x86_64
+name: all_cuda-132_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ files:
     output: [conda]
     matrix:
       # docs are only built on the latest CUDA version RAPIDS supports
-      cuda: ["13.1"]
+      cuda: ["13.2"]
       arch: [x86_64]
     includes:
       - checks
@@ -61,6 +61,10 @@ dependencies:
               cuda: "13.1"
             packages:
               - cuda-version=13.1
+          - matrix:
+              cuda: "13.2"
+            packages:
+              - cuda-version=13.2
 
   docs:
     common:

--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -38,7 +38,7 @@ Install and update cuGraph using the conda command:
 
 ```bash
 # CUDA 13
-conda install -c rapidsai -c conda-forge cugraph cuda-version=13.1
+conda install -c rapidsai -c conda-forge cugraph cuda-version=13.2
 
 # CUDA 12
 conda install -c rapidsai -c conda-forge cugraph cuda-version=12.9

--- a/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
@@ -34,7 +34,7 @@ Install and update WholeGraph using the conda command:
 
 ```bash
 # CUDA 13
-conda install -c rapidsai -c conda-forge wholegraph cuda-version=13.1
+conda install -c rapidsai -c conda-forge wholegraph cuda-version=13.2
 
 # CUDA 12
 conda install -c rapidsai -c conda-forge wholegraph cuda-version=12.9


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/265

* uses CUDA 13.2.0 to build and test
* updates to CUDA 13.2.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.2.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/545

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.
