### PR TITLE
fix(ci): add explicit `actions: write` permission for `telemetry-summarize`


### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,14 +1,11 @@
 name: pr
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
 jobs:
   pr-builder:
     needs:
@@ -24,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
-        OTEL_SERVICE_NAME: "pr-cugraph-docs"
+      OTEL_SERVICE_NAME: "pr-cugraph-docs"
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
@@ -54,3 +51,5 @@ jobs:
     steps:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-summarize@main
+    permissions:
+      actions: write


### PR DESCRIPTION
## Description
As part of https://github.com/rapidsai/build-planning/issues/275 we removed the default set of permissions from all workflow jobs.

The shared-action that handles telemetry cleanup is now failing because it is trying to clean up artifacts that shouldn't remain after a given workflow run.

This PR adds an explicit `actions: write` permission, to allow that action to clean up those artifacts.

xref https://github.com/rapidsai/shared-actions/issues/106
