### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ permissions: {}
 jobs:
   docs-build:
     if: github.ref_type == 'branch'
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       arch: "amd64"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,4 @@
 name: build
-
 on:
   push:
     branches:
@@ -27,11 +26,10 @@ on:
         description: "build_type: one of [branch, nightly, pull-request]"
         type: string
         default: nightly
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
-
+permissions: {}
 jobs:
   docs-build:
     if: github.ref_type == 'branch'
@@ -46,3 +44,9 @@ jobs:
       node_type: "gpu-l4-latest-1"
       script: "ci/build_docs.sh"
       sha: ${{ inputs.sha }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,6 @@ jobs:
       - telemetry-setup
       - checks
       - docs-build
-    secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
     if: always()
     with:
@@ -29,7 +28,6 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   checks:
-    secrets: inherit
     needs: telemetry-setup
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
     with:
@@ -39,7 +37,7 @@ jobs:
       contents: read
   docs-build:
     needs: checks
-    secrets: inherit
+    secrets: inherit # zizmor: ignore[secrets-inherit]
     uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
     with:
       build_type: pull-request

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,6 +6,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions: {}
 jobs:
   pr-builder:
     needs:
@@ -17,6 +18,8 @@ jobs:
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
+    permissions:
+      contents: read
   telemetry-setup:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -32,6 +35,8 @@ jobs:
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
+    permissions:
+      contents: read
   docs-build:
     needs: checks
     secrets: inherit
@@ -42,6 +47,12 @@ jobs:
       arch: "amd64"
       container_image: "rapidsai/ci-conda:26.08-latest"
       script: "ci/build_docs.sh"
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   telemetry-summarize:
     # This job must use a self-hosted runner to record telemetry traces.
     runs-on: linux-amd64-cpu4

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
     hooks:
       - id: shellcheck
         args: ["--severity=warning"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 
 default_language_version:
   python: python3


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275