### PR TITLE
fix random_walks references, bump Sphinx floor to 8.2

### DIFF
--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -14,7 +14,7 @@ dependencies:
 - ipython
 - libcugraph==26.6.*,>=0.0.0a0
 - libcugraph_etl==26.6.*,>=0.0.0a0
-- myst-parser>=0.13
+- myst-parser>=5.0
 - nbsphinx
 - numpydoc
 - pre-commit

--- a/conda/environments/all_cuda-132_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-132_arch-x86_64.yaml
@@ -21,8 +21,8 @@ dependencies:
 - pydata-sphinx-theme
 - pylibcugraph==26.6.*,>=0.0.0a0
 - pylibwholegraph==26.6.*,>=0.0.0a0
-- sphinx
 - sphinx-copybutton
 - sphinx-markdown-tables
+- sphinx>=8.2
 - sphinxcontrib-websupport
 name: all_cuda-132_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -73,7 +73,7 @@ dependencies:
           - breathe>=4.35
           - doxygen
           - ipython
-          - myst-parser>=0.13
+          - myst-parser>=5.0
           - nbsphinx
           - numpydoc
           - pydata-sphinx-theme

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -79,7 +79,7 @@ dependencies:
           - pydata-sphinx-theme
           - sphinx-copybutton
           - sphinx-markdown-tables
-          - sphinx
+          - sphinx>=8.2
           - sphinxcontrib-websupport
 
   # this repo only uses conda and 1 major version of CUDA, so

--- a/docs/cugraph-docs/source/api_docs/cugraph/sampling.rst
+++ b/docs/cugraph-docs/source/api_docs/cugraph/sampling.rst
@@ -15,7 +15,6 @@ single-GPU
    cugraph.biased_random_walks
    cugraph.heterogeneous_neighbor_sample
    cugraph.homogeneous_neighbor_sample
-   cugraph.random_walks
 
 multi-GPU
 ^^^^^^^^^
@@ -33,7 +32,7 @@ single-GPU
 .. autosummary::
    :toctree: ../api/cugraph/
 
-   cugraph.node2vec_random_walks.node2vec_random_walks
+   cugraph.sampling.node2vec_random_walks
 
 multi-GPU
 ^^^^^^^^^

--- a/docs/cugraph-docs/source/sphinxext/github_link.py
+++ b/docs/cugraph-docs/source/sphinxext/github_link.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2025, NVIDIA CORPORATION.
+# Copyright (c) 2019-2026, NVIDIA CORPORATION.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,7 +18,6 @@
 import inspect
 import re
 import subprocess
-from functools import partial
 from operator import attrgetter
 
 orig = inspect.isfunction
@@ -134,6 +133,8 @@ def make_linkcode_resolve(url_fmt):
                                    '{path}#L{lineno}')
     """
     revision = _get_git_revision()
-    return partial(_linkcode_resolve,
-                   revision=revision,
-                   url_fmt=url_fmt)
+
+    def linkcode_resolve(domain, info):
+        return _linkcode_resolve(domain, info, url_fmt=url_fmt, revision=revision)
+
+    return linkcode_resolve


### PR DESCRIPTION
Fixes #198 

## Fixes random walks references

Looks like the removals and reorganization in https://github.com/rapidsai/cugraph/pull/5122 broke some links here, but I think we didn't find out about it until now because `sphinx` or `myst` or something was being overly-permissive.

```text
WARNING: [autosummary] failed to import cugraph.node2vec_random_walks.node2vec_random_walks.
Possible hints:
* ModuleNotFoundError: No module named 'cugraph.node2vec_random_walks'
* AttributeError: 'function' object has no attribute 'node2vec_random_walks'
* ImportError: 
WARNING: [autosummary] failed to import cugraph.random_walks.
Possible hints:
* ImportError: 
* AttributeError: module 'cugraph' has no attribute 'random_walks'
* ModuleNotFoundError: No module named 'cugraph.random_walks'
```

Those broken links now result in hard build failures (yay!). This fixes them.

## Fixes `cugraph-pyg` references

Builds were failing with what turned out to be an import error:

```text
      File "/opt/conda/envs/docs/lib/python3.14/site-packages/sphinx/events.py", line 415, in emit
        raise ExtensionError(
        ...<4 lines>...
        ) from exc
    sphinx.errors.ExtensionError: Handler <function process_generate_options at 0x73f1825db8a0> for event 'builder-inited' threw an exception (exception: no module named cugraph_pyg.data.feature_store)
```

Fixed by https://github.com/rapidsai/cugraph-gnn/pull/470 and related PRs in https://github.com/rapidsai/build-planning/issues/284

## Resolves Sphinx warning

> WARNING: The config value `linkcode_resolve' has type `partial'; expected `NoneType' or `function'.

Looks like this is new validation that was added in `Sphinx` 8.2 (https://github.com/sphinx-doc/sphinx/pull/13324), so this PR also bumps the `sphinx` floor to 8.2.