### PR TITLE
Build and test with CUDA 13.3.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,7 @@ jobs:
   docs-build:
     if: github.ref_type == 'branch'
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       arch: "amd64"
       branch: ${{ inputs.branch }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,7 +13,7 @@ jobs:
       - telemetry-setup
       - checks
       - docs-build
-    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@cuda-13.3.0
     if: always()
     with:
       needs: ${{ toJSON(needs) }}
@@ -29,7 +29,7 @@ jobs:
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-base-env-vars@main
   checks:
     needs: telemetry-setup
-    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@cuda-13.3.0
     with:
       enable_check_generated_files: false
       ignored_pr_jobs: "telemetry-summarize"
@@ -38,7 +38,7 @@ jobs:
   docs-build:
     needs: checks
     secrets: inherit # zizmor: ignore[secrets-inherit]
-    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+    uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@cuda-13.3.0
     with:
       build_type: pull-request
       node_type: "gpu-l4-latest-1"

--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -7,7 +7,7 @@ channels:
 - pyg
 dependencies:
 - breathe>=4.35
-- cuda-version=13.2
+- cuda-version=13.3
 - cugraph-pyg==26.8.*,>=0.0.0a0
 - cugraph==26.8.*,>=0.0.0a0
 - doxygen
@@ -25,4 +25,4 @@ dependencies:
 - sphinx-markdown-tables
 - sphinx>=8.2
 - sphinxcontrib-websupport
-name: all_cuda-132_arch-x86_64
+name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,7 +4,7 @@ files:
     output: [conda]
     matrix:
       # docs are only built on the latest CUDA version RAPIDS supports
-      cuda: ["13.2"]
+      cuda: ["13.3"]
       arch: [x86_64]
     includes:
       - checks
@@ -65,6 +65,10 @@ dependencies:
               cuda: "13.2"
             packages:
               - cuda-version=13.2
+          - matrix:
+              cuda: "13.3"
+            packages:
+              - cuda-version=13.3
 
   docs:
     common:

--- a/docs/cugraph-docs/source/installation/getting_cugraph.md
+++ b/docs/cugraph-docs/source/installation/getting_cugraph.md
@@ -38,7 +38,7 @@ Install and update cuGraph using the conda command:
 
 ```bash
 # CUDA 13
-conda install -c rapidsai -c conda-forge cugraph cuda-version=13.2
+conda install -c rapidsai -c conda-forge cugraph cuda-version=13.3
 
 # CUDA 12
 conda install -c rapidsai -c conda-forge cugraph cuda-version=12.9

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -192,8 +192,8 @@ vi ./etc/conda/activate.d/env_vars.sh
 
 #!/bin/bash
 # for CUDA 13.x
-export PATH=/usr/local/cuda-13.1/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/cuda-13.1/lib64:$LD_LIBRARY_PATH
+export PATH=/usr/local/cuda-13.3/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/cuda-13.3/lib64:$LD_LIBRARY_PATH
 ```
 
 ```

--- a/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
+++ b/docs/cugraph-docs/source/wholegraph/installation/getting_wholegraph.md
@@ -34,7 +34,7 @@ Install and update WholeGraph using the conda command:
 
 ```bash
 # CUDA 13
-conda install -c rapidsai -c conda-forge wholegraph cuda-version=13.2
+conda install -c rapidsai -c conda-forge wholegraph cuda-version=13.3
 
 # CUDA 12
 conda install -c rapidsai -c conda-forge wholegraph cuda-version=12.9


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/286

* uses CUDA 13.3.0 to build and test
* updates to CUDA 13.3.0 devcontainers

## Notes for Reviewers

This switches GitHub Actions workflows to the `cuda-13.3.0` branch from here: https://github.com/rapidsai/shared-workflows/pull/574

A future round of PRs will revert that back to `main`, once all of RAPIDS is migrated.

