### PR TITLE
Update docs to use NVIDIA Sphinx theme

### DIFF
--- a/conda/environments/all_cuda-133_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-133_arch-x86_64.yaml
@@ -18,11 +18,12 @@ dependencies:
 - nbsphinx
 - numpydoc
 - pre-commit
-- pydata-sphinx-theme
 - pylibcugraph==26.8.*,>=0.0.0a0
 - pylibwholegraph==26.8.*,>=0.0.0a0
 - sphinx-copybutton
 - sphinx-markdown-tables
 - sphinx>=8.2
 - sphinxcontrib-websupport
+- pip:
+  - nvidia-sphinx-theme
 name: all_cuda-133_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -80,7 +80,8 @@ dependencies:
           - myst-parser>=5.0
           - nbsphinx
           - numpydoc
-          - pydata-sphinx-theme
+          - pip:
+              - nvidia-sphinx-theme
           - sphinx-copybutton
           - sphinx-markdown-tables
           - sphinx>=8.2

--- a/docs/cugraph-docs/source/_templates/sidebar-nav-bs.html
+++ b/docs/cugraph-docs/source/_templates/sidebar-nav-bs.html
@@ -10,11 +10,14 @@
   That is correct for nested pages, where the sidebar should still show the
   active section and its foldable children. For top-level section landing
   pages, that output duplicates the primary navbar item in the sidebar, so we
-  render only the active section's child <ul> on those landing pages.
+  render only the active section's child <ul> on those landing pages. Orphaned
+  autosummary pages have no navigation parent, so they cannot generate a
+  section toctree and intentionally omit it.
 #}
 {% set show_nav_level = meta['html_theme.show_nav_level'] if (meta is defined and meta is not none and 'html_theme.show_nav_level' in meta) else theme_show_nav_level %}
 {% set special_page = pagename == root_doc or pagename in ["genindex", "py-modindex", "search"] %}
-{% if not special_page %}
+{% set has_navigation_parent = parents is defined and parents %}
+{% if not special_page and has_navigation_parent %}
   {% set nav_tree = generate_toctree_html(
     "sidebar",
     startdepth=1,

--- a/docs/cugraph-docs/source/_templates/sidebar-nav-bs.html
+++ b/docs/cugraph-docs/source/_templates/sidebar-nav-bs.html
@@ -1,0 +1,43 @@
+{#
+  Override PyData Sphinx Theme's sidebar-nav-bs.html component.
+
+  NVIDIA Sphinx Theme inherits PyData's default primary sidebar configuration,
+  which includes this component by template name. Placing a file with the same
+  name in the project's _templates directory makes Sphinx use this version.
+
+  PyData's generate_toctree_html("sidebar", startdepth=1, ...) returns the
+  normal sidebar tree rooted at the currently active top-level toctree item.
+  That is correct for nested pages, where the sidebar should still show the
+  active section and its foldable children. For top-level section landing
+  pages, that output duplicates the primary navbar item in the sidebar, so we
+  render only the active section's child <ul> on those landing pages.
+#}
+{% set show_nav_level = meta['html_theme.show_nav_level'] if (meta is defined and meta is not none and 'html_theme.show_nav_level' in meta) else theme_show_nav_level %}
+{% set special_page = pagename == root_doc or pagename in ["genindex", "py-modindex", "search"] %}
+{% if not special_page %}
+  {% set nav_tree = generate_toctree_html(
+    "sidebar",
+    startdepth=1,
+    show_nav_level=show_nav_level | int,
+    maxdepth=theme_navigation_depth | int,
+    collapse=theme_collapse_navigation | tobool,
+    includehidden=theme_sidebar_includehidden | tobool,
+    titles_only=True,
+  ) %}
+  {% set pagename_parts = pagename.split("/") %}
+  {% set top_section_page = pagename_parts | length == 2 and pagename_parts[-1] == "index" %}
+  {% if top_section_page %}
+    {% set active_section = nav_tree.select_one("li.toctree-l1.current") %}
+    {% set active_details = active_section.find("details", recursive=False) if active_section else none %}
+    {% set section_nav = active_details.find("ul", recursive=False) if active_details else nav_tree %}
+  {% else %}
+    {% set section_nav = nav_tree %}
+  {% endif %}
+  <nav class="bd-docs-nav bd-links"
+       aria-label="{{ _('Section Navigation') }}">
+    <p class="bd-links__title" role="heading" aria-level="1">{{ _("Section Navigation") }}</p>
+    <div class="bd-toc-item navbar-nav">
+      {{ section_nav }}
+    </div>
+  </nav>
+{% endif %}

--- a/docs/cugraph-docs/source/conf.py
+++ b/docs/cugraph-docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2025, NVIDIA CORPORATION.
+# Copyright (c) 2018-2026, NVIDIA CORPORATION.
 #
 # pygdf documentation build configuration file, created by
 # sphinx-quickstart on Wed May  3 10:59:22 2017.
@@ -16,6 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import datetime
 import os
 import sys
 
@@ -79,9 +80,9 @@ templates_path = ['_templates']
 master_doc = 'index'
 
 # General information about the project.
-project = 'cugraph-docs'
-copyright = '2024-2025, NVIDIA Corporation'
-author = 'NVIDIA Corporation'
+project = "NVIDIA cuGraph"
+copyright = f"2024-{datetime.datetime.today().year}, NVIDIA Corporation"
+author = "NVIDIA Corporation"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/cugraph-docs/source/conf.py
+++ b/docs/cugraph-docs/source/conf.py
@@ -135,8 +135,14 @@ todo_include_todos = False
 #
 html_theme_options = {
     "external_links": [],
-    "github_url": "https://github.com/rapidsai/cugraph",
-    "twitter_url": "https://twitter.com/rapidsai",
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/rapidsai/cugraph",
+            "icon": "fa-brands fa-github",
+            "type": "fontawesome",
+        },
+    ],
     "show_toc_level": 1,
     "navbar_align": "right",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
@@ -179,7 +185,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'cugraph.tex', 'cugraph Documentation',
+    (master_doc, 'cugraph.tex', f'{project} Documentation',
      'NVIDIA Corporation', 'manual'),
 ]
 
@@ -189,7 +195,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'cugraph', 'cugraph Documentation',
+    (master_doc, 'cugraph', f'{project} Documentation',
      [author], 1)
 ]
 
@@ -200,7 +206,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'cugraph', 'cugraph Documentation',
+    (master_doc, 'cugraph', f'{project} Documentation',
      author, 'cugraph', 'GPU-accelerated graph analysis.',
      'Miscellaneous'),
 ]

--- a/docs/cugraph-docs/source/conf.py
+++ b/docs/cugraph-docs/source/conf.py
@@ -121,7 +121,7 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-html_theme = 'pydata_sphinx_theme'
+html_theme = 'nvidia_sphinx_theme'
 
 
 
@@ -138,6 +138,8 @@ html_theme_options = {
     "twitter_url": "https://twitter.com/rapidsai",
     "show_toc_level": 1,
     "navbar_align": "right",
+    "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
+    "navigation_with_keys": True,
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -213,8 +215,6 @@ numpydoc_class_members_toctree = False
 
 
 def setup(app):
-    app.add_css_file("https://docs.rapids.ai/assets/css/custom.css")
-    app.add_js_file("https://docs.rapids.ai/assets/js/custom.js", loading_method="defer")
     app.add_css_file("references.css")
 
 

--- a/docs/cugraph-docs/source/index.rst
+++ b/docs/cugraph-docs/source/index.rst
@@ -1,3 +1,5 @@
+NVIDIA cuGraph Documentation
+============================
 
 .. note::
 
@@ -15,11 +17,6 @@
    `RAPIDS nx-cugraph <https://rapids.ai/nx-cugraph/>`_ is now located in the `nx-cugraph repository <https://github.com/rapidsai/nx-cugraph>`_ containing a backend to NetworkX for running supported algorithms with GPU acceleration.
 
    The `cugraph-docs repository <https://github.com/rapidsai/cugraph-docs>`_ contains code to generate NVIDIA cuGraph documentation.
-
----
-
-NVIDIA cuGraph Documentation
-============================
 
 .. image:: images/cugraph_logo_2.png
    :width: 600
@@ -91,8 +88,6 @@ This includes several ways to set up cuGraph
  The cuGraph `test code <https://github.com/rapidsai/cugraph/tree/main/python/cugraph/cugraph/tests>`_ contains script examples of setting up and calling cuGraph algorithms.
 
  A simple example of `testing the degree centrality algorithm <https://github.com/rapidsai/cugraph/blob/HEAD/python/cugraph/cugraph/tests/centrality/test_degree_centrality.py>`_ is a good place to start. There are also `multi-GPU examples <https://github.com/rapidsai/cugraph/blob/HEAD/python/cugraph/cugraph/tests/centrality/test_degree_centrality_mg.py>`_ with larger data sets as well.
-
-----
 
 ~~~~~~~~~~~~~~~~~
 Table of Contents

--- a/docs/cugraph-docs/source/index.rst
+++ b/docs/cugraph-docs/source/index.rst
@@ -1,26 +1,25 @@
 
-*** NOTICE ***
-==============
+.. note::
 
-**cuGraph-DGL has been removed from cuGraph GNN as of release 25.06.** We recommend migrating to 
-cuGraph-PyG, which offers the same functionality along with additional features like support for heterogeneous sampling and a unified API. 
-The cuGraph team is not planning any further work in the DGL ecosystem going forward.
+   **cuGraph-DGL has been removed from cuGraph GNN as of release 25.06.** We recommend migrating to
+   cuGraph-PyG, which offers the same functionality along with additional features like support for heterogeneous sampling and a unified API.
+   The cuGraph team is not planning any further work in the DGL ecosystem going forward.
 
-The cuGraph repository has been refactored to make it more efficient to build, maintain and use.
+   The cuGraph repository has been refactored to make it more efficient to build, maintain and use.
 
-Libraries supporting GNNs are now located in the `cugraph-gnn repository <https://github.com/rapidsai/cugraph-gnn>`_
+   Libraries supporting GNNs are now located in the `cugraph-gnn repository <https://github.com/rapidsai/cugraph-gnn>`_.
 
-* `pylibwholegraph <https://github.com/rapidsai/cugraph-gnn/tree/main/python/>`_ - the `Wholegraph <https://docs.rapids.ai/api/cugraph/nightly/wholegraph/>`_ library for client memory management supporting cuGraph-PyG for even greater scalability
-* `cugraph_pyg <https://github.com/rapidsai/cugraph-gnn/blob/main/readme_pages/cugraph_pyg.md>`_ provides native implementations of Pytorch Geometric's (PyG's) `GraphStore`, `FeatureStore`, and `Loader` interfaces, unlocking powerful GPU-accelerated graph analytics—including neighborhood sampling, centrality metrics, and community detection—directly within PyG workflows.
+   * `pylibwholegraph <https://github.com/rapidsai/cugraph-gnn/tree/main/python/>`_ - the `Wholegraph <https://docs.rapids.ai/api/cugraph/nightly/wholegraph/>`_ library for client memory management supporting cuGraph-PyG for even greater scalability
+   * `cugraph_pyg <https://github.com/rapidsai/cugraph-gnn/blob/main/readme_pages/cugraph_pyg.md>`_ provides native implementations of Pytorch Geometric's (PyG's) `GraphStore`, `FeatureStore`, and `Loader` interfaces, unlocking powerful GPU-accelerated graph analytics—including neighborhood sampling, centrality metrics, and community detection—directly within PyG workflows.
 
-`RAPIDS nx-cugraph <https://rapids.ai/nx-cugraph/>`_ is now located in the `nx-cugraph repository <https://github.com/rapidsai/nx-cugraph>`_ containing a backend to NetworkX for running supported algorithms with GPU acceleration.
+   `RAPIDS nx-cugraph <https://rapids.ai/nx-cugraph/>`_ is now located in the `nx-cugraph repository <https://github.com/rapidsai/nx-cugraph>`_ containing a backend to NetworkX for running supported algorithms with GPU acceleration.
 
-The `cugraph-docs repository <https://github.com/rapidsai/cugraph-docs>`_ contains code to generate cuGraph documentation.
+   The `cugraph-docs repository <https://github.com/rapidsai/cugraph-docs>`_ contains code to generate NVIDIA cuGraph documentation.
 
 ---
 
-RAPIDS Graph documentation
-==========================
+NVIDIA cuGraph Documentation
+============================
 
 .. image:: images/cugraph_logo_2.png
    :width: 600
@@ -28,7 +27,7 @@ RAPIDS Graph documentation
 ~~~~~~~~~~~~
 Introduction
 ~~~~~~~~~~~~
-cuGraph is a library of graph algorithms that seamlessly integrates into the
+NVIDIA cuGraph is a library of graph algorithms that seamlessly integrates into the
 RAPIDS data science ecosystem and allows data scientists to easily call
 graph algorithms using data stored in cuDF/Pandas DataFrames or CuPy/SciPy
 sparse matrices.

--- a/docs/cugraph-docs/source/index.rst
+++ b/docs/cugraph-docs/source/index.rst
@@ -1,34 +1,54 @@
 NVIDIA cuGraph Documentation
 ============================
 
-.. note::
-
-   **cuGraph-DGL has been removed from cuGraph GNN as of release 25.06.** We recommend migrating to
-   cuGraph-PyG, which offers the same functionality along with additional features like support for heterogeneous sampling and a unified API.
-   The cuGraph team is not planning any further work in the DGL ecosystem going forward.
-
-   The cuGraph repository has been refactored to make it more efficient to build, maintain and use.
-
-   Libraries supporting GNNs are now located in the `cugraph-gnn repository <https://github.com/rapidsai/cugraph-gnn>`_.
-
-   * `pylibwholegraph <https://github.com/rapidsai/cugraph-gnn/tree/main/python/>`_ - the `Wholegraph <https://docs.rapids.ai/api/cugraph/nightly/wholegraph/>`_ library for client memory management supporting cuGraph-PyG for even greater scalability
-   * `cugraph_pyg <https://github.com/rapidsai/cugraph-gnn/blob/main/readme_pages/cugraph_pyg.md>`_ provides native implementations of Pytorch Geometric's (PyG's) `GraphStore`, `FeatureStore`, and `Loader` interfaces, unlocking powerful GPU-accelerated graph analytics—including neighborhood sampling, centrality metrics, and community detection—directly within PyG workflows.
-
-   `RAPIDS nx-cugraph <https://rapids.ai/nx-cugraph/>`_ is now located in the `nx-cugraph repository <https://github.com/rapidsai/nx-cugraph>`_ containing a backend to NetworkX for running supported algorithms with GPU acceleration.
-
-   The `cugraph-docs repository <https://github.com/rapidsai/cugraph-docs>`_ contains code to generate NVIDIA cuGraph documentation.
-
 .. image:: images/cugraph_logo_2.png
    :width: 600
 
-~~~~~~~~~~~~
-Introduction
-~~~~~~~~~~~~
-NVIDIA cuGraph is a library of graph algorithms that seamlessly integrates into the
-RAPIDS data science ecosystem and allows data scientists to easily call
-graph algorithms using data stored in cuDF/Pandas DataFrames or CuPy/SciPy
-sparse matrices.
+Overview
+--------
 
+NVIDIA cuGraph is an open-source collection of GPU-accelerated graph analytics
+libraries. It supports creating and manipulating graphs and running scalable
+graph algorithms. Its Python APIs integrate with data stored in cuDF and pandas
+DataFrames, CuPy and SciPy sparse matrices, and NetworkX graphs. Lower-level
+Python, C, and C++ APIs support applications that need closer integration with
+cuGraph's graph primitives.
+
+NVIDIA cuGraph libraries and supporting projects are maintained across several
+repositories:
+
+* `cuGraph <https://github.com/rapidsai/cugraph>`_ provides the core
+  GPU-accelerated graph analytics libraries, including the high-level
+  :doc:`Python API <api_docs/cugraph/index>`, the lower-level
+  :doc:`pylibcugraph Python API <api_docs/plc/pylibcugraph>`, the
+  :doc:`C API <api_docs/cugraph_c/index>`, and the
+  :doc:`C++ API <api_docs/cugraph_cpp/index>`.
+* `cuGraph-GNN <https://github.com/rapidsai/cugraph-gnn>`_ contains
+  GPU-accelerated packages for graph neural network workflows built on NVIDIA
+  cuGraph.
+
+  * `cuGraph-PyG <https://github.com/rapidsai/cugraph-gnn/tree/main/python/cugraph-pyg>`_
+    integrates NVIDIA cuGraph with PyTorch Geometric and implements its
+    ``GraphStore``, ``FeatureStore``, ``Loader``, and ``Sampler`` interfaces.
+    See the :doc:`Python API <api_docs/cugraph-pyg/cugraph_pyg>`.
+  * `pylibwholegraph <https://github.com/rapidsai/cugraph-gnn/tree/main/python/pylibwholegraph>`_
+    provides Python interfaces for distributed graph and key-value storage
+    through WholeGraph. cuGraph-PyG can use WholeGraph for greater scalability.
+    See the :doc:`Python API <api_docs/wholegraph/pylibwholegraph/index>`.
+
+* `nx-cugraph <https://github.com/rapidsai/nx-cugraph>`_ provides a NetworkX
+  backend that can accelerate supported NetworkX algorithms on NVIDIA GPUs with
+  zero code changes. See the :doc:`nx-cugraph documentation <nx_cugraph/index>`.
+* `cuGraph Docs <https://github.com/rapidsai/cugraph-docs>`_ contains the
+  documentation sources and build configuration for NVIDIA cuGraph and its
+  related libraries.
+
+.. note::
+
+   **cuGraph-DGL was removed in release 25.08.** We recommend migrating to
+   cuGraph-PyG, which provides the same functionality along with additional
+   features such as heterogeneous sampling and a unified API. The cuGraph team
+   is not planning further work in the DGL ecosystem.
 
 ---------------------------
 cuGraph Using NetworkX Code

--- a/docs/cugraph-docs/source/installation/source_build.md
+++ b/docs/cugraph-docs/source/installation/source_build.md
@@ -82,7 +82,7 @@ Note that libraries will be installed to the location set in `$PREFIX` if set
 
 #### Updating the RAFT branch
 
-`libcugraph` uses the [RAFT](https://github.com/rapidsai/raft) library and
+`libcugraph` uses the [RAFT](https://github.com/NVIDIA/raft) library and
 there are times when it might be desirable to build against a different RAFT
 branch, such as when working on new features that might span both RAFT and
 cuGraph.


### PR DESCRIPTION
## Description

Updates the Sphinx documentation to use `nvidia_sphinx_theme` with cuDF-style top navigation.

This replaces the PyData Sphinx Theme dependency, removes the legacy shared RAPIDS CSS/JavaScript injection, adds the sidebar override needed for section navigation with the top navbar, and regenerates dependency manifests. Orphaned autosummary pages omit the section sidebar because they have no navigation ancestor.

Contributes to rapidsai/build-planning#300.

## Validation

- Commit-time pre-commit hooks passed, including the RAPIDS dependency file generator.
- `sphinx-build -b dirhtml source _html` passed with published nightly Python packages and published Doxygen XML.
- Rendered landing pages use top navigation, nested pages retain section navigation, orphaned API leaves render successfully, and no legacy shared RAPIDS asset URLs remain.

