### PR TITLE
X-ORG-210: Enable docs version picker

### DIFF
--- a/docs/cugraph-docs/source/conf.py
+++ b/docs/cugraph-docs/source/conf.py
@@ -147,6 +147,10 @@ html_theme_options = {
     "navbar_align": "right",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/cugraph/versions.json",
+        "version_match": version,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Contributes to #210 

Let's enable the docs version picker.

N.B. I will backport this to 26.08 after the release to ensure it goes live for those docs.