### PR TITLE
Backport #212: Enable docs version picker

### DIFF
--- a/docs/cugraph-docs/source/conf.py
+++ b/docs/cugraph-docs/source/conf.py
@@ -147,6 +147,10 @@ html_theme_options = {
     "navbar_align": "right",
     "navbar_center": "navbar-nav, version-switcher, navbar-external-links",
     "navigation_with_keys": True,
+    "switcher": {
+        "json_url": "https://docs.nvidia.com/cugraph/versions.json",
+        "version_match": version,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,


### PR DESCRIPTION
Backport of #212, contributing to #210 for the 26.08 release.