### PR TITLE
Remove data stores docs section

### DIFF
--- a/docs/cugraph-docs/source/graph_support/datastores.rst
+++ b/docs/cugraph-docs/source/graph_support/datastores.rst
@@ -1,8 +1,0 @@
-Data Stores
-===========
-
-.. toctree::
-   :maxdepth: 3
-
-   knowledge_stores.md
-   feature_stores.md

--- a/docs/cugraph-docs/source/graph_support/feature_stores.md
+++ b/docs/cugraph-docs/source/graph_support/feature_stores.md
@@ -1,3 +1,0 @@
-# Feature Store
-
-Coming Soon

--- a/docs/cugraph-docs/source/graph_support/index.rst
+++ b/docs/cugraph-docs/source/graph_support/index.rst
@@ -10,4 +10,3 @@ Graph Support
    compatibility.rst
    cugraph_cpp.rst
    gnn_support.rst
-   datastores.rst

--- a/docs/cugraph-docs/source/graph_support/knowledge_stores.md
+++ b/docs/cugraph-docs/source/graph_support/knowledge_stores.md
@@ -1,3 +1,0 @@
-# Knowledge Store
-
-Coming Soon


### PR DESCRIPTION
## Summary

- remove the Data Stores entry from the Graph Support navigation
- delete the placeholder Data Stores landing page
- delete the orphaned Knowledge Store and Feature Store “Coming Soon” pages

## Why

The Data Stores section is placeholder content and should no longer appear in the cuGraph documentation.

## Impact

The Data Stores section and its two placeholder child pages will no longer be published or shown in the Graph Support navigation.

## Validation

- `git diff --check`
- confirmed there are no remaining references to `datastores`, `knowledge_stores`, or `feature_stores` under the docs source tree
- full Sphinx build not run because it requires the cuGraph development environment and Sphinx is not installed in this workspace
